### PR TITLE
Mimic Java DataConverter behavior depending on argument length

### DIFF
--- a/cadence/activity_loop.py
+++ b/cadence/activity_loop.py
@@ -4,6 +4,7 @@ import json
 
 from cadence.cadence_types import PollForActivityTaskRequest, TaskListMetadata, TaskList, PollForActivityTaskResponse, \
     RespondActivityTaskCompletedRequest, RespondActivityTaskFailedRequest
+from cadence.conversions import json_to_args
 from cadence.workflowservice import WorkflowService
 
 logger = logging.getLogger(__name__)
@@ -39,7 +40,7 @@ def activity_task_loop(worker):
                 logger.debug("PollForActivityTask has no task_token (expected): %s", task)
                 continue
 
-            args = json.loads(task.input)
+            args = json_to_args(task.input)
             logger.info(f"Request for activity: {task.activity_type.name}")
             fn = worker.activities.get(task.activity_type.name)
             if not fn:

--- a/cadence/activity_method.py
+++ b/cadence/activity_method.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Callable, List
 
 from cadence.cadence_types import ActivityType
+from cadence.conversions import args_to_json
 
 
 def get_activity_method_name(method: Callable):
@@ -43,7 +44,7 @@ def activity_method(func: Callable = None, name: str = "", schedule_to_close_tim
             assert self._decision_context
             assert stub_activity_fn._execute_parameters
             parameters = copy.deepcopy(stub_activity_fn._execute_parameters)
-            parameters.input = json.dumps(args if args else None).encode("utf-8")
+            parameters.input = args_to_json(args).encode("utf-8")
             from cadence.decision_loop import DecisionContext
             decision_context: DecisionContext = self._decision_context
             return await decision_context.schedule_activity_task(parameters=parameters)

--- a/cadence/conversions.py
+++ b/cadence/conversions.py
@@ -1,3 +1,4 @@
+import json
 import typing
 import inspect
 import re
@@ -110,3 +111,22 @@ def get_python_type(thrift_class: type) -> type:
     python_cls = getattr(cadence.cadence_types, thrift_class.__name__, None)
     assert python_cls, "Python class not found: " + thrift_class.__name__
     return python_cls
+
+
+def args_to_json(args: list) -> str:
+    if args is None or len(args) == 0:
+        return json.dumps(None)
+    elif len(args) == 1:
+        return json.dumps(args[0])
+    else:
+        return json.dumps(args)
+
+
+def json_to_args(jsonb: bytes) -> typing.Optional[list]:
+    parsed = json.loads(jsonb)
+    if parsed is None:
+        return []
+    elif isinstance(parsed, list):
+        return parsed
+    else:
+        return [parsed]

--- a/cadence/decision_loop.py
+++ b/cadence/decision_loop.py
@@ -25,6 +25,7 @@ from cadence.cadence_types import PollForDecisionTaskRequest, TaskList, PollForD
     CompleteWorkflowExecutionDecisionAttributes, Decision, DecisionType, RespondDecisionTaskCompletedResponse, \
     HistoryEvent, EventType, WorkflowType, ScheduleActivityTaskDecisionAttributes, \
     CancelWorkflowExecutionDecisionAttributes, StartTimerDecisionAttributes, TimerFiredEventAttributes
+from cadence.conversions import json_to_args
 from cadence.decisions import DecisionId, DecisionTarget
 from cadence.exceptions import WorkflowTypeNotFound, NonDeterministicWorkflowException, ActivityTaskFailedException, \
     ActivityTaskTimeoutException, SignalNotFound
@@ -493,9 +494,7 @@ class ReplayDecider:
         if start_event_attributes.input is None:
             workflow_input = []
         else:
-            workflow_input = json.loads(start_event_attributes.input)
-            if not isinstance(workflow_input, list):
-                workflow_input = [workflow_input]
+            workflow_input = json_to_args(start_event_attributes.input)
         self.workflow_task = WorkflowMethodTask(task_id=self.execution_id, workflow_input=workflow_input,
                                                 worker=self.worker, workflow_type=self.workflow_type, decider=self)
         self.event_loop.run_event_loop_once()
@@ -578,9 +577,7 @@ class ReplayDecider:
         if not signal_input:
             signal_input = []
         else:
-            signal_input = json.loads(signaled_event_attributes.input)
-            if not isinstance(signal_input, list):
-                signal_input = [signal_input]
+            signal_input = json_to_args(signal_input)
 
         task = SignalMethodTask(task_id=self.execution_id,
                                 workflow_instance=self.workflow_task.workflow_instance,

--- a/cadence/tests/test_activity_method.py
+++ b/cadence/tests/test_activity_method.py
@@ -92,6 +92,26 @@ class ActivityMethodTest(TestCase):
         args, kwargs = self.decision_context.schedule_activity_task.call_args_list[0]
         self.assertEqual(b"null", kwargs["parameters"].input)
 
+    def test_invoke_stub_with_one_arg(self):
+        class HelloActivities:
+            @activity_method(task_list="test-tasklist")
+            def hello(self, arg1):
+                pass
+
+        stub = HelloActivities()
+        stub._decision_context = self.decision_context
+
+        async def fn():
+            await stub.hello(1)
+
+        loop = get_event_loop()
+        self.task = loop.create_task(fn())
+        run_once(loop)
+
+        self.decision_context.schedule_activity_task.assert_called_once()
+        args, kwargs = self.decision_context.schedule_activity_task.call_args_list[0]
+        self.assertEqual(b'1', kwargs["parameters"].input)
+
     def test_invoke_stub_with_args(self):
         class HelloActivities:
             @activity_method(task_list="test-tasklist")

--- a/cadence/tests/test_decision_loop.py
+++ b/cadence/tests/test_decision_loop.py
@@ -141,6 +141,20 @@ class TestDecisionTaskLoop(TestCase):
         complete_workflow = decisions[0].complete_workflow_execution_decision_attributes
         self.assertEqual("null", complete_workflow.result)
 
+    def test_one_arg(self):
+        class DummyWorkflow:
+            @workflow_method()
+            async def dummy(self, arg1):
+                nonlocal arg1_value
+                arg1_value = arg1
+
+        arg1_value = None
+        self.worker.register_workflow_implementation_type(DummyWorkflow)
+        self.poll_response.history.events[0].workflow_execution_started_event_attributes.input = json.dumps(
+            ["first"])
+        self.loop.process_task(self.poll_response)
+        self.assertEqual(arg1_value, "first")
+
     def test_args(self):
         class DummyWorkflow:
             @workflow_method()

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from cadence.cadence_types import WorkflowIdReusePolicy, StartWorkflowExecutionRequest, TaskList, WorkflowType, \
     GetWorkflowExecutionHistoryRequest, WorkflowExecution, HistoryEventFilterType, EventType, HistoryEvent, \
     StartWorkflowExecutionResponse, SignalWorkflowExecutionRequest
+from cadence.conversions import args_to_json
 from cadence.workflowservice import WorkflowService
 
 
@@ -148,7 +149,7 @@ def exec_signal(workflow_client: WorkflowClient, sm: SignalMethod, args, stub_in
     request = SignalWorkflowExecutionRequest()
     request.workflow_execution = stub_instance._execution
     request.signal_name = sm.name
-    request.input = json.dumps(args)
+    request.input = args_to_json(args)
     request.domain = workflow_client.domain
     response, err = workflow_client.service.signal_workflow_execution(request)
     if err:
@@ -164,7 +165,7 @@ def create_start_workflow_request(workflow_client: WorkflowClient, wm: WorkflowM
     start_request.workflow_type.name = wm._name
     start_request.task_list = TaskList()
     start_request.task_list.name = wm._task_list
-    start_request.input = json.dumps(args)
+    start_request.input = args_to_json(args)
     start_request.execution_start_to_close_timeout_seconds = wm._execution_start_to_close_timeout_seconds
     start_request.task_start_to_close_timeout_seconds = wm._task_start_to_close_timeout_seconds
     start_request.identity = workflow_client.service.get_identity()


### PR DESCRIPTION
We're attempting to use the Cadence Python library to interoperate with some workflows implemented in Java, namely to start workflows and get the result. It's working well except for one issue.

The trouble is that the Python client does not serialize single or zero argument workflow method calls the same was as the Java client's `JsonDataConverter`. Namely, the Java client expects a zero-arg method's input to be serialized as JSON `null`, and a single argument method's input to be serialized alone without be wrapped in an array. In contrast, the existing Python code serializes zero-arg method inputs as `[]`, and wraps single arguments in a JSON array.

Reference to the Java code: https://github.com/uber/cadence-java-client/blob/master/src/main/java/com/uber/cadence/converter/JsonDataConverter.java#L85

This PR attempts to make the minimum changes required to interoperate properly with workers running the Java client. 

