### PR TITLE
LOGNAME ENV preffered over getlogin

### DIFF
--- a/cadence/connection.py
+++ b/cadence/connection.py
@@ -194,7 +194,7 @@ class ThriftFunctionCall(ThriftArgScheme):
     @staticmethod
     def default_application_headers():
         return {
-            "user-name": os.getlogin(),
+            "user-name": os.environ.get("LOGNAME", os.getlogin()),
             "host-name": socket.gethostname(),
             # Copied from Java client
             "cadence-client-library-version": "2.2.0",


### PR DESCRIPTION
There exists several issues with calling `os.getlogin()`.  The method is optional when building python and the method may not be present.  Furthermore, there may not be a value to return.  This is a notable problem in docker containers and lambdas, and will cause failure.

This pull request adds a check for the `LOGNAME` env variable, which in many systems should give interchangeable results with `os.getlogin()`.  This will not fix docker containers, but fortunately the user can manually define the `LOGNAME` ENV to avoid failure.