### PR TITLE
Fix setup.py by including rest of required dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,14 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/firdaus/cadence-python",
     packages=setuptools.find_packages(exclude=["cadence.tests", "cadence.spikes"]),
-    install_requires=["more-itertools>=7.0.0", "thriftrw>=1.7.2"],
+    install_requires=[
+        "dataclasses-json>=0.3.8",
+        "more-itertools>=7.0.0",
+        "ply>=3.11",
+        "six>=1.12.0",
+        "tblib>=1.6.0",
+        "thriftrw>=1.7.2",
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
After installing cadence-python from source via `setup.py` it turned out that worker is failing with `no module named...` errors. Necessary packages were included in `requirements.txt` but not in `install_requires` list in `setup.py`. This PR fixes it.

I tested it by doing `python setup.py install` and running example workflow before and after the change on **clean virtual env**. 