### PR TITLE
Use getpass replacing os

### DIFF
--- a/cadence/connection.py
+++ b/cadence/connection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+import getpass
 import socket
 from dataclasses import dataclass
 from io import BytesIO
@@ -194,7 +194,7 @@ class ThriftFunctionCall(ThriftArgScheme):
     @staticmethod
     def default_application_headers():
         return {
-            "user-name": os.environ.get("LOGNAME", os.getlogin()),
+            "user-name": getpass.getuser(),
             "host-name": socket.gethostname(),
             # Copied from Java client
             "cadence-client-library-version": "2.2.0",


### PR DESCRIPTION
I used cadence-client in docker and encountered an error:
```bash
[Errno 2] No such file or directory
```
After debugging, it shows that the error is caused by os.getlogin().
As saying [here](https://docs.python.org/3/library/os.html#os.getlogin), getpass.getuser() is better than os.getlogin() for most purpose.
This is the code of getpass.getuser():
```python
def getuser():
    """Get the username from the environment or password database.

    First try various environment variables, then the password
    database.  This works on Windows as long as USERNAME is set.

    """

    for name in ('LOGNAME', 'USER', 'LNAME', 'USERNAME'):
        user = os.environ.get(name)
        if user:
            return user

    # If this fails, the exception will "explain" why
    import pwd
    return pwd.getpwuid(os.getuid())[0]
```