### PR TITLE
Add min. Py3 version required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p>
+<img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/cadence-client">
+</p>
+
 # Intro: Fault-Oblivious Stateful Python Code
 
 cadence-python allows you to create Python functions that have their state (local variables etc..) implicitly saved such that if the process/machine fails the state of the function is not lost and can resume from where it left off. 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setuptools.setup(
     ],
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
I figured it'd be useful to make this explicit. Many out there are still using Python 3.6 because that's what what you get in LTS distros like Ubuntu 18.04 for example.