### PR TITLE
Worker error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,113 @@
-# Python framework for Cadence Workflow Service
+# Intro: Fault-Oblivious Stateful Python Code
 
-[Cadence](https://github.com/uber/cadence) is a workflow engine developed at Uber Engineering. With this framework, workflows and activities managed by Cadence can be implemented in Python code.
+cadence-python allows you to create Python functions that have their state (local variables etc..) implicitly saved such that if the process/machine fails the state of the function is not lost and can resume from where it left off. 
+
+This programming model is useful whenever you need to ensure that a function runs to completion. For example:
+
+- Business logic involving multiple micro services
+- CI/CD pipelines
+- Data pipelines
+- RPA
+- ETL
+- Marketing automation / Customer journeys / Customer engagement
+- Zapier/IFTTT like end user automation.
+- Chat bots
+- Multi-step forms
+- Scheduler/Cron jobs
+
+Behind the scenes, cadence-python uses [Cadence](https://github.com/uber/cadence) as its backend. 
+
+For more information about the fault-oblivious programming model refer to the Cadence documentation [here](https://cadenceworkflow.io/docs/03_concepts/01_workflows)
+
+## Install Cadencce
+
+```
+wget https://raw.githubusercontent.com/uber/cadence/master/docker/docker-compose.yml
+docker-compose up
+```
+
+## Register `sample` domain
+
+```
+docker run --network=host --rm ubercadence/cli:master --do sample domain register -rd 1
+```
+
+## Installation cadence-python
+
+```
+pip install cadence-client==1.0.0b3
+```
+
+## Hello World Sample
+
+```python
+import sys
+import logging
+from cadence.activity_method import activity_method
+from cadence.workerfactory import WorkerFactory
+from cadence.workflow import workflow_method, Workflow, WorkflowClient
+
+logging.basicConfig(level=logging.DEBUG)
+
+TASK_LIST = "HelloActivity-python-tasklist"
+DOMAIN = "sample"
+
+
+# Activities Interface
+class GreetingActivities:
+    @activity_method(task_list=TASK_LIST, schedule_to_close_timeout_seconds=2)
+    def compose_greeting(self, greeting: str, name: str) -> str:
+        raise NotImplementedError
+
+
+# Activities Implementation
+class GreetingActivitiesImpl:
+    def compose_greeting(self, greeting: str, name: str):
+        return f"{greeting} {name}!"
+
+
+# Workflow Interface
+class GreetingWorkflow:
+    @workflow_method(execution_start_to_close_timeout_seconds=10, task_list=TASK_LIST)
+    async def get_greeting(self, name: str) -> str:
+        raise NotImplementedError
+
+
+# Workflow Implementation
+class GreetingWorkflowImpl(GreetingWorkflow):
+
+    def __init__(self):
+        self.greeting_activities: GreetingActivities = Workflow.new_activity_stub(GreetingActivities)
+
+    async def get_greeting(self, name):
+        # Place any Python code here that you want to ensure is executed to completion.
+        # Note: code in workflow functions must be deterministic so that the same code paths
+        # are ran during replay.
+        return await self.greeting_activities.compose_greeting("Hello", name)
+
+
+if __name__ == '__main__':
+    factory = WorkerFactory("localhost", 7933, DOMAIN)
+    worker = factory.new_worker(TASK_LIST)
+    worker.register_activities_implementation(GreetingActivitiesImpl(), "GreetingActivities")
+    worker.register_workflow_implementation_type(GreetingWorkflowImpl)
+    factory.start()
+
+    client = WorkflowClient.new_client(domain=DOMAIN)
+    greeting_workflow: GreetingWorkflow = client.new_workflow_stub(GreetingWorkflow)
+    result = greeting_workflow.get_greeting("Python")
+    print(result)
+
+    print("Stopping workers....")
+    worker.stop()
+    print("Workers stopped...")
+    sys.exit(0)
+``` 
 
 ## Status / TODO
 
 cadence-python is still under going heavy development. It should be considered EXPERIMENTAL at the moment. A production
-version is targeted to be released in ~~September of 2019~~ ~~January 2020~~ March 2020.
+version is targeted to be released in ~~September of 2019~~ ~~January 2020~~ ~~March 2020~~ April 2020.
 
 1.0
 - [x] Tchannel implementation
@@ -45,77 +147,11 @@ version is targeted to be released in ~~September of 2019~~ ~~January 2020~~ Mar
 
 Post 2.0:
 - [ ] sideEffect/mutableSideEffect
+- [ ] Local activity
 - [ ] Parallel activity execution
 - [ ] Timers
 - [ ] Cancellation Scopes
 - [ ] Child Workflows
 - [ ] Explicit activity ids for activity invocations
 
-## Installation
 
-```
-pip install cadence-client
-```
-
-## Hello World Sample
-
-```
-import sys
-import logging
-from cadence.activity_method import activity_method
-from cadence.workerfactory import WorkerFactory
-from cadence.workflow import workflow_method, Workflow, WorkflowClient
-
-logging.basicConfig(level=logging.DEBUG)
-
-TASK_LIST = "HelloActivity-python-tasklist"
-DOMAIN = "sample"
-
-
-# Activities Interface
-class GreetingActivities:
-    @activity_method(task_list=TASK_LIST, schedule_to_close_timeout_seconds=2)
-    def compose_greeting(self, greeting: str, name: str) -> str:
-        raise NotImplementedError
-
-
-# Activities Implementation
-class GreetingActivitiesImpl:
-    def compose_greeting(self, greeting: str, name: str):
-        return greeting + " " + name + "!"
-
-
-# Workflow Interface
-class GreetingWorkflow:
-    @workflow_method(execution_start_to_close_timeout_seconds=10, task_list=TASK_LIST)
-    async def get_greeting(self, name: str) -> str:
-        raise NotImplementedError
-
-
-# Workflow Implementation
-class GreetingWorkflowImpl(GreetingWorkflow):
-
-    def __init__(self):
-        self.greeting_activities: GreetingActivities = Workflow.new_activity_stub(GreetingActivities)
-
-    async def get_greeting(self, name):
-        return await self.greeting_activities.compose_greeting("Hello", name)
-
-
-if __name__ == '__main__':
-    factory = WorkerFactory("localhost", 7933, DOMAIN)
-    worker = factory.new_worker(TASK_LIST)
-    worker.register_activities_implementation(GreetingActivitiesImpl(), "GreetingActivities")
-    worker.register_workflow_implementation_type(GreetingWorkflowImpl)
-    factory.start()
-
-    client = WorkflowClient.new_client(domain=DOMAIN)
-    greeting_workflow: GreetingWorkflow = client.new_workflow_stub(GreetingWorkflow)
-    result = greeting_workflow.get_greeting("Python")
-    print(result)
-
-    print("Stopping workers....")
-    worker.stop()
-    print("Workers stopped...")
-    sys.exit(0)
-```

--- a/cadence/activity_loop.py
+++ b/cadence/activity_loop.py
@@ -41,7 +41,9 @@ def activity_task_loop(worker: Worker):
                 continue
             if err:
                 logger.error("PollForActivityTask failed: %s", err)
-                continue
+                logger.info(f"trying to restart worker and returning from current method")
+                worker.start()
+                return
             task_token = task.task_token
             if not task_token:
                 logger.debug("PollForActivityTask has no task_token (expected): %s", task)

--- a/cadence/activity_loop.py
+++ b/cadence/activity_loop.py
@@ -38,13 +38,13 @@ def activity_task_loop(worker: Worker):
                 return
             except Exception as ex:
                 logger.error("PollForActivityTask error: %s", ex)
-                continue
-            if err:
-                logger.error("PollForActivityTask failed: %s", err)
                 logger.info(f"trying to restart worker and returning from current method")
                 worker.stop()
                 worker.start()
                 return
+            if err:
+                logger.error("PollForActivityTask failed: %s", err)
+                continue
             task_token = task.task_token
             if not task_token:
                 logger.debug("PollForActivityTask has no task_token (expected): %s", task)

--- a/cadence/activity_loop.py
+++ b/cadence/activity_loop.py
@@ -38,10 +38,7 @@ def activity_task_loop(worker: Worker):
                 return
             except Exception as ex:
                 logger.error("PollForActivityTask error: %s", ex)
-                logger.info(f"trying to restart worker and returning from current method")
-                worker.stop()
-                worker.start()
-                return
+                raise
             if err:
                 logger.error("PollForActivityTask failed: %s", err)
                 continue

--- a/cadence/activity_loop.py
+++ b/cadence/activity_loop.py
@@ -42,6 +42,7 @@ def activity_task_loop(worker: Worker):
             if err:
                 logger.error("PollForActivityTask failed: %s", err)
                 logger.info(f"trying to restart worker and returning from current method")
+                worker.stop()
                 worker.start()
                 return
             task_token = task.task_token

--- a/cadence/activity_method.py
+++ b/cadence/activity_method.py
@@ -54,6 +54,8 @@ def activity_method(func: Callable = None, name: str = "", schedule_to_close_tim
             assert self._decision_context
             assert stub_activity_fn._execute_parameters
             parameters = copy.deepcopy(stub_activity_fn._execute_parameters)
+            if hasattr(self, "_activity_options") and self._activity_options:
+                self._activity_options.fill_execute_activity_parameters(parameters)
             if self._retry_parameters:
                 parameters.retry_parameters = self._retry_parameters
             parameters.input = args_to_json(args).encode("utf-8")
@@ -80,3 +82,24 @@ def activity_method(func: Callable = None, name: str = "", schedule_to_close_tim
         raise Exception("activity_method must be called with arguments")
     else:
         return wrapper
+
+
+@dataclass
+class ActivityOptions:
+    schedule_to_close_timeout_seconds: int = None
+    schedule_to_start_timeout_seconds: int = None
+    start_to_close_timeout_seconds: int = None
+    heartbeat_timeout_seconds: int = None
+    task_list: str = None
+
+    def fill_execute_activity_parameters(self, execute_parameters: ExecuteActivityParameters):
+        if self.schedule_to_close_timeout_seconds is not None:
+            execute_parameters.schedule_to_close_timeout_seconds = self.schedule_to_close_timeout_seconds
+        if self.schedule_to_start_timeout_seconds is not None:
+            execute_parameters.schedule_to_start_timeout_seconds = self.schedule_to_start_timeout_seconds
+        if self.start_to_close_timeout_seconds is not None:
+            execute_parameters.start_to_close_timeout_seconds = self.start_to_close_timeout_seconds
+        if self.heartbeat_timeout_seconds is not None:
+            execute_parameters.heartbeat_timeout_seconds = self.heartbeat_timeout_seconds
+        if self.task_list is not None:
+            execute_parameters.task_list = self.task_list

--- a/cadence/connection.py
+++ b/cadence/connection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import getpass
 import os
 import socket
 from dataclasses import dataclass
@@ -194,7 +195,7 @@ class ThriftFunctionCall(ThriftArgScheme):
     @staticmethod
     def default_application_headers():
         return {
-            "user-name": os.environ.get("LOGNAME", os.getlogin()),
+            "user-name": getpass.getuser(),
             "host-name": socket.gethostname(),
             # Copied from Java client
             "cadence-client-library-version": "2.2.0",

--- a/cadence/constants.py
+++ b/cadence/constants.py
@@ -1,3 +1,7 @@
 
 CODE_OK = 0x00
 CODE_ERROR = 0x01
+
+# This should be at least 60 seconds because Cadence will reply after 60 seconds when polling
+# if there is nothing pending
+DEFAULT_SOCKET_TIMEOUT_SECONDS = 120

--- a/cadence/errors.py
+++ b/cadence/errors.py
@@ -8,6 +8,9 @@ from typing import Optional
 class BadRequestError(Exception):
     message: str
 
+    def __str__(self):
+        return self.message
+
 
 @dataclass
 class InternalServiceError(Exception):
@@ -37,6 +40,9 @@ class WorkflowExecutionAlreadyStartedError(Exception):
 @dataclass
 class EntityNotExistsError(Exception):
     message: str
+
+    def __str__(self):
+        return self.message
 
 
 @dataclass

--- a/cadence/exception_handling.py
+++ b/cadence/exception_handling.py
@@ -49,6 +49,9 @@ def serialize_exception(ex: Exception):
 
 
 def deserialize_exception(details) -> Exception:
+    """
+    TODO: Support built-in types like Exception
+    """
     exception: Exception = None
     details_dict = json.loads(details)
     source = details_dict.get("source")

--- a/cadence/marker.py
+++ b/cadence/marker.py
@@ -70,7 +70,7 @@ class MarkerData(MarkerInterface):
 class MarkerResult:
     data: bytes = None
     access_count: int = 0
-    replayed = False
+    replayed: bool = False
 
 
 @dataclass

--- a/cadence/samples/hello_activity_async.py
+++ b/cadence/samples/hello_activity_async.py
@@ -53,7 +53,7 @@ if __name__ == '__main__':
     client = WorkflowClient.new_client(domain=DOMAIN)
     greeting_workflow: GreetingWorkflow = client.new_workflow_stub(GreetingWorkflow)
     execution = WorkflowClient.start(greeting_workflow.get_greeting, "Python")
-    print("Started: workflow_id={} run_id={}".format(execution.workflow_id, execution.run_id))
+    print("Started: workflow_id={} run_id={}".format(execution.workflow_execution.workflow_id, execution.workflow_execution.run_id))
     print("Result: " + str(client.wait_for_close(execution)))
 
     print("Stopping workers....")

--- a/cadence/tests/test_activity_method.py
+++ b/cadence/tests/test_activity_method.py
@@ -2,7 +2,7 @@ from _asyncio import get_event_loop
 from unittest import TestCase
 from unittest.mock import Mock, MagicMock
 
-from cadence.activity_method import activity_method, ExecuteActivityParameters
+from cadence.activity_method import activity_method, ExecuteActivityParameters, ActivityOptions
 from cadence.decision_loop import DecisionContext
 from cadence.tests.test_decision_context import run_once
 
@@ -80,6 +80,7 @@ class ActivityMethodTest(TestCase):
 
         stub = HelloActivities()
         stub._decision_context = self.decision_context
+        stub._retry_parameters = None
 
         async def fn():
             await stub.hello()
@@ -100,6 +101,7 @@ class ActivityMethodTest(TestCase):
 
         stub = HelloActivities()
         stub._decision_context = self.decision_context
+        stub._retry_parameters = None
 
         async def fn():
             await stub.hello(1)
@@ -120,6 +122,7 @@ class ActivityMethodTest(TestCase):
 
         stub = HelloActivities()
         stub._decision_context = self.decision_context
+        stub._retry_parameters = None
 
         async def fn():
             await stub.hello(1, "one")
@@ -131,3 +134,34 @@ class ActivityMethodTest(TestCase):
         self.decision_context.schedule_activity_task.assert_called_once()
         args, kwargs = self.decision_context.schedule_activity_task.call_args_list[0]
         self.assertEqual(b'[1, "one"]', kwargs["parameters"].input)
+
+    def test_invoke_with_activity_options(self):
+        class HelloActivities:
+            @activity_method(task_list="test-tasklist")
+            def hello(self, arg1, arg2):
+                pass
+
+        stub = HelloActivities()
+        stub._decision_context = self.decision_context
+        stub._retry_parameters = None
+        stub._activity_options = ActivityOptions(schedule_to_close_timeout_seconds=50,
+                                                 schedule_to_start_timeout_seconds=100,
+                                                 start_to_close_timeout_seconds=150,
+                                                 heartbeat_timeout_seconds=200,
+                                                 task_list="tasklist-tasklist-tasklist")
+
+        async def fn():
+            await stub.hello(1, "one")
+
+        loop = get_event_loop()
+        self.task = loop.create_task(fn())
+        run_once(loop)
+
+        self.decision_context.schedule_activity_task.assert_called_once()
+        args, kwargs = self.decision_context.schedule_activity_task.call_args_list[0]
+        parameters: ExecuteActivityParameters = kwargs["parameters"]
+        self.assertEquals(parameters.schedule_to_close_timeout_seconds, 50)
+        self.assertEquals(parameters.schedule_to_start_timeout_seconds, 100)
+        self.assertEquals(parameters.start_to_close_timeout_seconds, 150)
+        self.assertEquals(parameters.heartbeat_timeout_seconds, 200)
+        self.assertEquals(parameters.task_list, "tasklist-tasklist-tasklist")

--- a/cadence/tests/test_decision_events.py
+++ b/cadence/tests/test_decision_events.py
@@ -1,11 +1,12 @@
 import pytest
 
+from cadence.cadence_types import HistoryEvent, EventType
 from cadence.decision_loop import DecisionEvents
 
 
 @pytest.fixture()
 def event_object():
-    return object()
+    return HistoryEvent()
 
 
 @pytest.fixture()
@@ -31,3 +32,16 @@ def test_get_optional_event_negative(decision_events):
 def test_get_optional_event_too_large(decision_events):
     e = decision_events.get_optional_decision_event(25)
     assert e is None
+
+
+def test_markers():
+    marker = HistoryEvent(event_type=EventType.MarkerRecorded)
+    events = [
+        HistoryEvent(event_type=EventType.WorkflowExecutionStarted),
+        HistoryEvent(event_type=EventType.ActivityTaskScheduled),
+        HistoryEvent(event_type=EventType.ActivityTaskCanceled),
+        marker
+    ]
+    decision_events = DecisionEvents(events=[], decision_events=events, replay=True, replay_current_time_milliseconds=0, next_decision_event_id=10)
+    assert len(decision_events.markers) == 1
+    assert id(decision_events.markers[0]) == id(marker)

--- a/cadence/tests/test_java.py
+++ b/cadence/tests/test_java.py
@@ -1,3 +1,5 @@
+# TODO: Re-enable once interoperability is a design goal again
+"""
 from unittest import TestCase
 import logging.config
 from uuid import uuid4
@@ -39,4 +41,4 @@ class TestWorkflowExecutionFromJava(TestCase):
         greeting = stub.getGreeting("World")
         self.assertEqual("Hello World", greeting)
 
-
+"""

--- a/cadence/tests/test_query_workflow.py
+++ b/cadence/tests/test_query_workflow.py
@@ -60,7 +60,7 @@ def test_query_workflow():
 
     client = WorkflowClient.new_client(domain=DOMAIN)
     workflow: TestQueryWorkflow = client.new_workflow_stub(TestQueryWorkflow)
-    WorkflowClient.start(workflow.get_greetings)
+    workflow_ec = WorkflowClient.start(workflow.get_greetings)
 
     assert workflow.get_message() == "initial-message"
     workflow.put_message("second-message")
@@ -72,6 +72,10 @@ def test_query_workflow():
     assert isinstance(ex.__cause__, GreetingException)
 
     workflow.put_message("done")
+
+    client.wait_for_close(workflow_ec)
+
+    assert workflow.get_message() == "done"
 
     print("Stopping workers")
     worker.stop()

--- a/cadence/tests/test_version.py
+++ b/cadence/tests/test_version.py
@@ -50,10 +50,12 @@ def test_clock_decision_context_get_version(decision_context):
 
 
 def test_clock_decision_context_get_version_stored(decision_context):
+    # is_replaying=True
     decision_context.workflow_clock.version_handler.mutable_marker_results["abc"] = MarkerResult(data="3")
     version = decision_context.workflow_clock.get_version("abc", 1, 5)
     assert version == 3
-    assert len(decision_context.decider.decisions) == 0
+    # decision needs to be emitted during replay to make things deterministic
+    assert len(decision_context.decider.decisions) == 1
 
 
 @pytest.fixture()
@@ -86,10 +88,10 @@ def version_decision_context(version_marker_recorded_event):
 
 
 def test_clock_decision_context_from_replay(version_decision_context):
-    version_decision_context.workflow_clock.set_replaying(True)
-    version = version_decision_context.workflow_clock.get_version("abc", 1, 5)
-    assert version == -1
-    assert len(version_decision_context.decider.decisions) == 0
+    with pytest.raises(Exception) as exc_info:
+        version_decision_context.workflow_clock.set_replaying(True)
+        version = version_decision_context.workflow_clock.get_version("abc", 1, 5)
+    assert "Version -1 of changeID abc is not supported. Supported version is between 1 and 5" in str(exc_info.value)
 
 
 def test_validate_version(version_decision_context):

--- a/cadence/tests/test_workflowservice.py
+++ b/cadence/tests/test_workflowservice.py
@@ -341,19 +341,6 @@ class TestStartWorkflow(TestCase):
         self.assertIsNone(err)
         self.assertIsNotNone(response)
 
-    def test_query_workflow_timeout(self):
-        start_response, _ = self.service.start_workflow(self.request)
-        request = QueryWorkflowRequest()
-        request.domain = "test-domain"
-        request.execution = WorkflowExecution()
-        request.execution.workflow_id = self.request.workflow_id
-        request.execution.run_id = start_response.run_id
-        request.query = WorkflowQuery()
-        request.query.query_type = "getDummy"
-        request.query.query_args = None
-        with self.assertRaisesRegex(TChannelException, "timeout") as context:
-            self.service.query_workflow(request)
-
     def test_describe_workflow_execution(self):
         start_response, _ = self.service.start_workflow(self.request)
         request = DescribeWorkflowExecutionRequest()

--- a/cadence/thrift/thrift-parser.js
+++ b/cadence/thrift/thrift-parser.js
@@ -1,0 +1,641 @@
+class ThriftFileParsingError extends SyntaxError {
+  constructor({ message, context, line }) {
+    super(message);
+    this.context = context;
+    this.line = line;
+    this.name = 'THRIFT_FILE_PARSING_ERROR';
+  }
+}
+
+module.exports = (source, offset = 0) => {
+
+  source += '';
+
+  let nCount = 0;
+  let rCount = 0;
+
+  let stack = [];
+
+  const record = char => {
+    if (char === '\r') rCount++;
+    else if (char === '\n') nCount++;
+  };
+  const save = () => stack.push({ offset, nCount, rCount });
+  const restore = () => ({ offset, nCount, rCount } = stack[stack.length - 1]);
+  const drop = () => stack.pop();
+
+  const readAnyOne = (...args) => {
+    save();
+    for (let i = 0; i < args.length; i++) {
+      try {
+        let result = args[i]();
+        drop();
+        return result;
+      } catch (ignore) {
+        restore();
+        continue;
+      }
+    }
+    drop();
+    throw 'Unexcepted Token';
+  };
+
+  const readUntilThrow = (transaction, key) => {
+    let receiver = key ? {} : [];
+    for (;;) {
+      try {
+        save();
+        let result = transaction();
+        key ? receiver[result[key]] = result : receiver.push(result);
+      } catch (ignore) {
+        restore();
+        return receiver;
+      } finally {
+        drop();
+      }
+    }
+  };
+
+  const readKeyword = word => {
+    for (let i = 0; i < word.length; i++) {
+      if (source[offset + i] !== word[i]) {
+        throw 'Unexpected token "' + word + '"';
+      }
+    }
+    offset += word.length;
+    readSpace();
+    return word;
+  };
+
+  const readChar = (char) => {
+    if (source[offset] !== char) throw 'Unexpected char "' + char + '"';
+    offset++;
+    readSpace();
+    return char;
+  };
+
+  const readNoop = () => {};
+
+  const readCommentMultiple = () => {
+    let i = 0;
+    if (source[offset + i++] !== '/' || source[offset + i++] !== '*') return false;
+    do {
+      record(source[offset + i]);
+      while (offset + i < source.length && source[offset + i++] !== '*') {
+        record(source[offset + i]);
+      }
+    } while (offset + i < source.length && source[offset + i] !== '/');
+    offset += i + 1;
+    return true;
+  };
+
+  const readCommentSharp = () => {
+    let i = 0;
+    if (source[offset + i++] !== '#') return false;
+    while (source[offset + i] !== '\n' && source[offset + i] !== '\r') offset++;
+    offset += i;
+    return true;
+  };
+
+  const readCommentDoubleSlash = () => {
+    let i = 0;
+    if (source[offset + i++] !== '/' || source[offset + i++] !== '/') return false;
+    while (source[offset + i] !== '\n' && source[offset + i] !== '\r') offset++;
+    offset += i;
+    return true;
+  };
+
+  const readSpace = () => {
+    for (;;) {
+      let byte = source[offset];
+      record(byte);
+      if (byte === '\n' || byte === '\r' || byte === ' ' || byte === '\t') {
+        offset++;
+      } else {
+        if (!readCommentMultiple() && !readCommentSharp() && !readCommentDoubleSlash()) return;
+      }
+    }
+  };
+
+  const readComma = () => {
+    if (source[offset] === ',' || source[offset] === ';') {
+      offset++;
+      readSpace();
+      return ',';
+    }
+  };
+
+  const readTypedef = () => {
+    let subject = readKeyword('typedef');
+    let type = readType();
+    let name = readName();
+    readComma();
+    return {subject, type, name};
+  };
+
+  const readType = () => readAnyOne(readTypeMap, readTypeList, readTypeNormal);
+
+  const readTypeMap = () => {
+    let name = readKeyword('map');
+    readChar('<');
+    let keyType = readType();
+    readComma();
+    let valueType = readType();
+    readChar('>');
+    return {name, keyType, valueType};
+  };
+
+  const readTypeList = () => {
+    let name = readAnyOne(() => readKeyword('list'), () => readKeyword('set'));
+    readChar('<');
+    let valueType = readType();
+    readChar('>');
+    return {name, valueType};
+  };
+
+  const readTypeNormal = () => readName();
+
+  const readName = () => {
+    let i = 0;
+    let byte = source[offset];
+    while (
+      (byte >= 'a' && byte <= 'z') ||
+      byte === '.' ||
+      byte === '_' ||
+      (byte >= 'A' && byte <= 'Z') ||
+      (byte >= '0' && byte <= '9')
+    ) byte = source[offset + ++i];
+    if (i === 0) throw 'Unexpected token on readName';
+    let value = source.slice(offset, offset += i);
+    readSpace();
+    return value;
+  };
+
+  const readScope = () => {
+    let i = 0;
+    let byte = source[offset];
+    while (
+      (byte >= 'a' && byte <= 'z') ||
+      byte === '_' ||
+      (byte >= 'A' && byte <= 'Z') ||
+      (byte >= '0' && byte <= '9') ||
+      (byte === '*') ||
+      (byte === '.')
+    ) byte = source[offset + ++i];
+    if (i === 0) throw 'Unexpected token on readScope';
+    let value = source.slice(offset, offset += i);
+    readSpace();
+    return value;
+  };
+
+  const readNumberSign = () => {
+    let result;
+    if (source[offset] === '+' || source[offset] === '-') {
+      result = source[offset];
+      offset++;
+    }
+    return result;
+  };
+
+  const readIntegerValue = () => {
+    let result = [];
+    let sign = readNumberSign();
+    if (sign !== void 0) result.push(sign);
+
+    for (; ;) {
+      let byte = source[offset];
+      if ((byte >= '0' && byte <= '9')) {
+        offset++;
+        result.push(byte);
+      } else if (
+        byte === 'E' || byte === 'e' ||
+        byte === 'X' || byte === 'x' ||
+        byte === '.'
+      ) {
+        throw `Unexpected token ${byte} for integer value`;
+      } else {
+        if (result.length) {
+          readSpace();
+          return +result.join('');
+        } else {
+          throw 'Unexpected token ' + byte;
+        }
+      }
+    }
+  };
+
+  const readDecimalValue = () => {
+    let result = [];
+    let sign = readNumberSign();
+    if (sign !== void 0) result.push(sign);
+
+    for (;;) {
+      let byte = source[offset];
+      if ((byte >= '0' && byte <= '9') || byte === '.') {
+        offset++;
+        result.push(byte);
+      } else {
+        if (result.length) {
+          readSpace();
+          return +result.join('');
+        } else {
+          throw 'Unexpected token ' + byte;
+        }
+      }
+    }
+  };
+
+  const readEnotationValue = () => {
+    let result = [];
+    if (source[offset] === '-') {
+      result.push(source[offset]);
+      offset++;
+    }
+
+    for (;;) {
+      let byte = source[offset];
+      if ((byte >= '0' && byte <= '9') || byte === '.') {
+        result.push(byte);
+        offset++;
+      } else {
+        break;
+      }
+    }
+
+    if (source[offset] !== 'e' && source[offset] !== 'E') throw 'Unexpected token';
+    result.push(source[offset]);
+    offset++;
+
+    for (;;) {
+      let byte = source[offset];
+      if (byte >= '0' && byte <= '9') {
+        offset++;
+        result.push(byte);
+      } else {
+        if (result.length) {
+          readSpace();
+          return +result.join('');
+        } else {
+          throw 'Unexpected token ' + byte;
+        }
+      }
+    }
+  };
+
+  const readHexadecimalValue = () => {
+    let result = [];
+    if (source[offset] === '-') {
+      result.push(source[offset]);
+      offset++;
+    }
+
+    if (source[offset] !== '0') throw 'Unexpected token';
+    result.push(source[offset]);
+    offset++;
+
+    if (source[offset] !== 'x' && source[offset] !== 'X') throw 'Unexpected token';
+    result.push(source[offset]);
+    offset++;
+
+    for (;;) {
+      let byte = source[offset];
+      if (
+        (byte >= '0' && byte <= '9') ||
+        (byte >= 'A' && byte <= 'F') ||
+        (byte >= 'a' && byte <= 'f')
+      ) {
+        offset++;
+        result.push(byte);
+      } else {
+        if (result.length) {
+          readSpace();
+          return +result.join('');
+        } else {
+          throw 'Unexpected token ' + byte;
+        }
+      }
+    }
+  };
+
+  const readBooleanValue = () => JSON.parse(readAnyOne(() => readKeyword('true'), () => readKeyword('false')));
+
+  const readRefValue = () => {
+    let list = [readName()];
+    readUntilThrow(() => {
+      readChar('.');
+      list.push(readName());
+    });
+    return {'=': list};
+  };
+
+  const readStringValue = () => {
+    let receiver = [];
+    let start;
+    while (source[offset] != null) {
+      let byte = source[offset++];
+      if (receiver.length) {
+        if (byte === start) {
+          receiver.push(byte);
+          readSpace();
+          return receiver.slice(1, -1).join('');
+        } else if (byte === '\\') {
+          receiver.push(byte);
+          offset++;
+          receiver.push(source[offset++]);
+        } else {
+          receiver.push(byte);
+        }
+      } else {
+        if (byte === '"' || byte === '\'') {
+          start = byte;
+          receiver.push(byte);
+        } else {
+          throw 'Unexpected token ILLEGAL';
+        }
+      }
+    }
+    throw 'Unterminated string value';
+  };
+
+  const readListValue = () => {
+    readChar('[');
+    let list = readUntilThrow(() => {
+      let value = readValue();
+      readComma();
+      return value;
+    });
+    readChar(']');
+    return list;
+  };
+
+  const readMapValue = () => {
+    readChar('{');
+    let list = readUntilThrow(() => {
+      let key = readValue();
+      readChar(':');
+      let value = readValue();
+      readComma();
+      return {key, value};
+    });
+    readChar('}');
+    return list;
+  };
+
+  const readValue = () => readAnyOne(
+    readHexadecimalValue, // This coming before readNumberValue is important, unfortunately
+    readEnotationValue,   // This also needs to come before readNumberValue
+    readDecimalValue,
+    readIntegerValue,
+    readStringValue,
+    readBooleanValue,
+    readListValue,
+    readMapValue,
+    readRefValue
+  );
+
+  const readConst = () => {
+    let subject = readKeyword('const');
+    let type = readType();
+    let name = readName();
+    readChar('=');
+    let value = readValue();
+    readComma();
+    return {subject, type, name, value};
+  };
+
+  const readEnum = () => {
+    let subject = readKeyword('enum');
+    let name = readName();
+    let items = readEnumBlock();
+    return {subject, name, items};
+  };
+
+  const readEnumBlock = () => {
+    readChar('{');
+    let receiver = readUntilThrow(readEnumItem);
+    readChar('}');
+    return receiver;
+  };
+
+  const readEnumItem = () => {
+    let name = readName();
+    let value = readEnumValue();
+    readComma();
+    let result = {name};
+    if (value !== void 0) result.value = value;
+    return result;
+  };
+
+  const readEnumValue = () => {
+    let beginning = offset;
+    try {
+      readChar('=');
+    } catch (ignore) {
+      offset = beginning;
+      return;
+    }
+    return readAnyOne(readHexadecimalValue, readIntegerValue);
+  };
+
+  const readAssign = () => {
+    try {
+      save();
+      readChar('=');
+      return readValue();
+    } catch (ignore) {
+      restore();
+    } finally {
+      drop();
+    }
+  };
+
+  const readStruct = () => {
+    let subject = readKeyword('struct');
+    let name = readName();
+    let items = readStructLikeBlock();
+    return {subject, name, items};
+  };
+
+  const readStructLikeBlock = () => {
+    readChar('{');
+    let receiver = readUntilThrow(readStructLikeItem);
+    readChar('}');
+    return receiver;
+  };
+
+  const readStructLikeItem = () => {
+    let id;
+    try {
+      id = readAnyOne(readHexadecimalValue, readIntegerValue);
+      readChar(':');
+    } catch (err) {
+
+    }
+
+    let option = readAnyOne(() => readKeyword('required'), () => readKeyword('optional'), readNoop);
+    let type = readType();
+    let name = readName();
+    let defaultValue = readAssign();
+    readComma();
+    let result = {type, name};
+    if (id !== void 0) result.id = id;
+    if (option !== void 0) result.option = option;
+    if (defaultValue !== void 0) result.defaultValue = defaultValue;
+    return result;
+  };
+
+  const readUnion = () => {
+    let subject = readKeyword('union');
+    let name = readName();
+    let items = readStructLikeBlock();
+    return {subject, name, items};
+  };
+
+  const readException = () => {
+    let subject = readKeyword('exception');
+    let name = readName();
+    let items = readStructLikeBlock();
+    return {subject, name, items};
+  };
+
+  const readExtends = () => {
+    try {
+      save();
+      readKeyword('extends');
+      let name = readRefValue()['='].join('.');
+      return name;
+    } catch (ignore) {
+      restore();
+      return;
+    } finally {
+      drop();
+    }
+  };
+
+  const readService = () => {
+    let subject = readKeyword('service');
+    let name = readName();
+    let extend = readExtends(); // extends is a reserved keyword
+    let functions = readServiceBlock();
+    let result = {subject, name};
+    if (extend !== void 0) result.extends = extend;
+    if (functions !== void 0) result.functions = functions;
+    return result;
+  };
+
+  const readNamespace = () => {
+    let subject = readKeyword('namespace');
+    let name = readScope();
+    let serviceName = readRefValue()['='].join('.');
+    return {subject, name, serviceName};
+  };
+
+  const readInclude = () => {
+    let subject = readKeyword('include');
+    readSpace();
+    let includePath = readQuotation();
+    let name = includePath.replace(/^.*?([^/\\]*?)(?:\.thrift)?$/, '$1');
+    readSpace();
+    return {subject, name, path: includePath};
+  };
+
+  const readQuotation = () => {
+    let quoteMatch;
+    if (source[offset] === '"' || source[offset] === '\'') {
+      quoteMatch = source[offset];
+      offset++;
+    } else {
+      throw 'include error';
+    }
+    let i = offset;
+    // Read until it finds a matching quote or end-of-file
+    while (source[i] !== quoteMatch && source[i] != null) {
+      i++;
+    }
+    if (source[i] === quoteMatch) {
+      let value = source.slice(offset, i);
+      offset = i + 1;
+      return value;
+    } else {
+      throw 'include error';
+    }
+  };
+
+  const readServiceBlock = () => {
+    readChar('{');
+    let receiver = readUntilThrow(readServiceItem, 'name');
+    readChar('}');
+    return receiver;
+  };
+
+  const readOneway = () => readKeyword('oneway');
+
+  const readServiceItem = () => {
+    let oneway = !!readAnyOne(readOneway, readNoop);
+    let type = readType();
+    let name = readName();
+    let args = readServiceArgs();
+    let throws = readServiceThrow();
+    readComma();
+    return {type, name, args, throws, oneway};
+  };
+
+  const readServiceArgs = () => {
+    readChar('(');
+    let receiver = readUntilThrow(readStructLikeItem);
+    readChar(')');
+    readSpace();
+    return receiver;
+  };
+
+  const readServiceThrow = () => {
+    try {
+      save();
+      readKeyword('throws');
+      return readServiceArgs();
+    } catch (ignore) {
+      restore();
+      return [];
+    } finally {
+      drop();
+    }
+  };
+
+  const readSubject = () => {
+    return readAnyOne(readTypedef, readConst, readEnum, readStruct, readUnion, readException, readService, readNamespace, readInclude);
+  };
+
+  const readThrift = () => {
+    readSpace();
+    let storage = {};
+    for (;;) {
+      try {
+        let block = readSubject();
+        let {subject, name} = block;
+        if (!storage[subject]) storage[subject] = {};
+        delete block.subject;
+        delete block.name;
+        switch (subject) {
+          case 'exception':
+          case 'struct':
+          case 'union':
+            storage[subject][name] = block.items;
+            break;
+          default:
+            storage[subject][name] = block;
+        }
+      } catch (message) {
+        let context = source.slice(offset, offset + 50);
+        let line = Math.max(nCount, rCount) + 1;
+        console.log("message=" + message + " context=" + context + " line=" + line);
+        throw new ThriftFileParsingError({ message, context, line });
+      } finally {
+        if (source.length === offset) break;
+      }
+    }
+    return storage;
+  };
+
+  return readThrift();
+
+};

--- a/cadence/thrift/thrift-parser.js-LICENSE
+++ b/cadence/thrift/thrift-parser.js-LICENSE
@@ -1,0 +1,27 @@
+I took thrift-parser.js from here:
+
+https://github.com/eleme/thrift-parser
+
+The license for which is:
+
+The MIT License (MIT)
+
+Copyright (c) <2016-2017> <Eleme Inc.>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/cadence/worker.py
+++ b/cadence/worker.py
@@ -5,6 +5,7 @@ import threading
 import logging
 import time
 
+from cadence.constants import DEFAULT_SOCKET_TIMEOUT_SECONDS
 from cadence.conversions import camel_to_snake, snake_to_camel
 from cadence.workflow import WorkflowMethod, SignalMethod, QueryMethod
 from cadence.workflowservice import WorkflowService
@@ -69,6 +70,7 @@ class Worker:
     threads_stopped: int = 0
     stop_requested: bool = False
     service_instances: List[WorkflowService] = field(default_factory=list)
+    timeout: int = DEFAULT_SOCKET_TIMEOUT_SECONDS
 
     def register_activities_implementation(self, activities_instance: object, activities_cls_name: str = None):
         cls_name = activities_cls_name if activities_cls_name else type(activities_instance).__name__
@@ -149,4 +151,16 @@ class Worker:
     def manage_service(self, service: WorkflowService):
         self.service_instances.append(service)
 
+    def set_timeout(self, timeout):
+        self.timeout = timeout
 
+    def get_timeout(self):
+        return self.timeout
+
+    def raise_if_stop_requested(self):
+        if self.is_stop_requested():
+            raise StopRequestedException()
+
+
+class StopRequestedException(Exception):
+    pass

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -8,14 +8,14 @@ from dataclasses import dataclass, field
 from typing import Callable, List, Type, Dict, Tuple
 from uuid import uuid4
 
-from six import reraise
 
 from cadence.activity import ActivityCompletionClient
-from cadence.activity_method import RetryParameters
+from cadence.activity_method import RetryParameters, ActivityOptions
 from cadence.cadence_types import WorkflowIdReusePolicy, StartWorkflowExecutionRequest, TaskList, WorkflowType, \
     GetWorkflowExecutionHistoryRequest, WorkflowExecution, HistoryEventFilterType, EventType, HistoryEvent, \
     StartWorkflowExecutionResponse, SignalWorkflowExecutionRequest, QueryWorkflowRequest, WorkflowQuery, \
     QueryWorkflowResponse
+from cadence.constants import DEFAULT_SOCKET_TIMEOUT_SECONDS
 from cadence.conversions import args_to_json, json_to_args
 from cadence.errors import QueryFailedError
 from cadence.exception_handling import deserialize_exception
@@ -27,13 +27,14 @@ from cadence.workflowservice import WorkflowService
 class Workflow:
 
     @staticmethod
-    def new_activity_stub(activities_cls, retry_parameters: RetryParameters = None):
+    def new_activity_stub(activities_cls, retry_parameters: RetryParameters = None, activity_options: ActivityOptions = None):
         from cadence.decision_loop import ITask
         task: ITask = ITask.current()
         assert task
         cls = activities_cls()
         cls._decision_context = task.decider.decision_context
         cls._retry_parameters = retry_parameters
+        cls._activity_options = activity_options
         return cls
 
     @staticmethod
@@ -88,6 +89,19 @@ class Workflow:
         task: ITask = ITask.current()
         return task.decider.decision_context.get_logger(name)
 
+    @staticmethod
+    def get_workflow_id():
+        from cadence.decision_loop import ITask
+        task: ITask = ITask.current()
+        return task.decider.workflow_id
+
+    @staticmethod
+    def get_execution_id():
+        from cadence.decision_loop import ITask
+        task: ITask = ITask.current()
+        return task.decider.execution_id
+
+
 
 class WorkflowStub:
     pass
@@ -107,8 +121,8 @@ class WorkflowClient:
 
     @classmethod
     def new_client(cls, host: str = "localhost", port: int = 7933, domain: str = "",
-                   options: WorkflowClientOptions = None) -> WorkflowClient:
-        service = WorkflowService.create(host, port)
+                   options: WorkflowClientOptions = None, timeout: int = DEFAULT_SOCKET_TIMEOUT_SECONDS) -> WorkflowClient:
+        service = WorkflowService.create(host, port, timeout=timeout)
         return cls(service=service, domain=domain, options=options)
 
     @classmethod
@@ -194,7 +208,7 @@ def exec_workflow(workflow_client, wm: WorkflowMethod, args, workflow_options: W
     start_request = create_start_workflow_request(workflow_client, wm, args)
     start_response, err = workflow_client.service.start_workflow(start_request)
     if err:
-        raise Exception(repr(err))
+        raise Exception(err)
     execution = WorkflowExecution(workflow_id=start_request.workflow_id, run_id=start_response.run_id)
     stub_instance._execution = execution
     return WorkflowExecutionContext(workflow_type=wm._name, workflow_execution=execution)
@@ -427,3 +441,4 @@ class WorkflowExecutionTerminatedException(Exception):
 
     def __str__(self) -> str:
         return self.reason
+

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -194,7 +194,7 @@ def exec_workflow(workflow_client, wm: WorkflowMethod, args, workflow_options: W
     start_request = create_start_workflow_request(workflow_client, wm, args)
     start_response, err = workflow_client.service.start_workflow(start_request)
     if err:
-        raise Exception(err)
+        raise Exception(repr(err))
     execution = WorkflowExecution(workflow_id=start_request.workflow_id, run_id=start_response.run_id)
     stub_instance._execution = execution
     return WorkflowExecutionContext(workflow_type=wm._name, workflow_execution=execution)

--- a/cadence/workflowservice.py
+++ b/cadence/workflowservice.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Tuple, Callable
 from uuid import uuid4
 
 import os
@@ -31,8 +31,8 @@ TCHANNEL_SERVICE = "cadence-frontend"
 class WorkflowService:
 
     @classmethod
-    def create(cls, host: str, port: int):
-        connection = TChannelConnection.open(host, port)
+    def create(cls, host: str, port: int, timeout: int = None):
+        connection = TChannelConnection.open(host, port, timeout=timeout)
         return cls(connection)
 
     @classmethod
@@ -170,3 +170,6 @@ class WorkflowService:
 
     def close(self):
         self.connection.close()
+
+    def set_next_timeout_cb(self, cb: Callable):
+        self.connection.set_next_timeout_cb(cb)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 more-itertools==7.0.0
 ply==3.11
-six==1.12.0
 tblib==1.6.0
 thriftrw==1.7.2
 dataclasses-json==0.3.8

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cadence-client",
-    version="0.0.4",
+    version="1.0.0-beta3",
     author="Mohammed Firdaus",
     author_email="firdaus.halim@gmail.com",
     description="Python framework for Cadence Workflow Service",
@@ -13,9 +13,17 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/firdaus/cadence-python",
     packages=setuptools.find_packages(exclude=["cadence.tests", "cadence.spikes"]),
-    install_requires=["more-itertools>=7.0.0", "thriftrw>=1.7.2"],
+    install_requires=[
+        "dataclasses-json>=0.3.8",
+        "more-itertools>=7.0.0",
+        "ply>=3.11",
+        "tblib>=1.6.0",
+        "thriftrw>=1.7.2",
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
- Issue:
In case worker loses connection to cadence (say, due to cadence server restart etc), it doesn't try to re-establish the connection. 
[I tried to fix](https://github.com/firdaus/cadence-python/pull/22) by letting the worker connect to cadence again - but it didn't work and threw other errors:  

so - now thinking to kill the worker by raising exception so that the pod will restart and connect to cadence again
