### PR TITLE
Add TerminateIfRunning to WorkflowIdReusePolicy

### DIFF
--- a/cadence/cadence_types.py
+++ b/cadence/cadence_types.py
@@ -97,6 +97,7 @@ class WorkflowIdReusePolicy(IntEnum):
     AllowDuplicateFailedOnly = 0
     AllowDuplicate = 1
     RejectDuplicate = 2
+    TerminateIfRunning = 3
     
     @classmethod
     def value_for(cls, n: int) -> WorkflowIdReusePolicy:

--- a/cadence/thrift/shared.json
+++ b/cadence/thrift/shared.json
@@ -187,6 +187,9 @@
         },
         {
           "name": "RejectDuplicate"
+        },
+        {
+          "name": "TerminateIfRunning"
         }
       ]
     },

--- a/cadence/thrift/shared.thrift
+++ b/cadence/thrift/shared.thrift
@@ -99,6 +99,16 @@ enum WorkflowIdReusePolicy {
    * do not allow start a workflow execution using the same workflow ID at all
    */
   RejectDuplicate,
+  /*
+   * Terminate any existing runs before starting
+   * Always allow starting a workflow execution using the same workflow ID,
+   * regardless of whether the last execution state was any of
+   * [completed, terminated, cancelled, timeouted, failed]
+   * This is the best option when:
+   *   1. Retriggering a workflow after it already completed
+   *   2. Changing the CRON schedule of a workflow
+   */
+  TerminateIfRunning,
 }
 
 enum DomainStatus {


### PR DESCRIPTION
Use Cases:
1. If you want to repeat a `completed` workflow with the same workflow id
2. If you want to change the CRON schedule of an existing workflow